### PR TITLE
Use always UTC Timezone in SiteRM.

### DIFF
--- a/src/python/SiteFE/LookUpService/lookup.py
+++ b/src/python/SiteFE/LookUpService/lookup.py
@@ -9,7 +9,7 @@ Date: 2021/12/01
 """
 from __future__ import division
 
-import datetime
+from datetime import datetime, timezone
 import os
 import time
 
@@ -115,7 +115,7 @@ class LookUpService(SwitchInfo, NodeInfo, DeltaInfo, RDFHelper, BWService):
 
     def getModelSavePath(self):
         """Get Model Save Location."""
-        now = datetime.datetime.now()
+        now = datetime.now(timezone.utc)
         saveDir = f"{self.config.get(self.sitename, 'privatedir')}/{'LookUpService'}"
         createDirs(saveDir)
         self.modelVersion = (

--- a/src/python/SiteFE/PolicyService/policyService.py
+++ b/src/python/SiteFE/PolicyService/policyService.py
@@ -197,7 +197,7 @@ class PolicyService(RDFHelper, Timing):
                 if not tout:
                     continue
                 try:
-                    temptime = int(time.mktime(parser.parse(str(tout[0])).timetuple()))
+                    temptime = int(parser.parse(str(tout[0])).timestamp())
                 except Exception:
                     temptime = tout[0]
                 try:

--- a/src/python/SiteFE/ProvisioningService/provisioningService.py
+++ b/src/python/SiteFE/ProvisioningService/provisioningService.py
@@ -21,7 +21,7 @@ Date                    : 2017/09/26
 UpdateDate              : 2022/05/09
 """
 import copy
-import datetime
+from datetime import datetime, timezone
 import sys
 
 from SiteFE.ProvisioningService.modules.RoutingService import RoutingService
@@ -75,7 +75,7 @@ class ProvisioningService(RoutingService, VirtualSwitchingService, BWService, Ti
             self.yamlconfuuidActive = {}
 
     def _forceApply(self):
-        curDate = datetime.datetime.now().strftime("%Y-%m-%d")
+        curDate = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         if self.lastApplied != curDate:
             self.lastApplied = curDate
             return True

--- a/src/python/SiteRMAgent/RecurringActions/Plugins/CertInfo.py
+++ b/src/python/SiteRMAgent/RecurringActions/Plugins/CertInfo.py
@@ -7,7 +7,6 @@ Authors:
 Date: 2022/12/23
 """
 import os.path
-import time
 import pprint
 from datetime import datetime
 from OpenSSL import crypto
@@ -36,10 +35,10 @@ class CertInfo:
         subject = cert.get_subject()
         out['subject'] = "".join(f"/{name.decode():s}={value.decode():s}"
                                  for name, value in subject.get_components())
-        out['notAfter'] = int(time.mktime(datetime.strptime(cert.get_notAfter().decode('UTF-8'),
-                                                            '%Y%m%d%H%M%SZ').timetuple()))
-        out['notBefore'] = int(time.mktime(datetime.strptime(cert.get_notBefore().decode('UTF-8'),
-                                                             '%Y%m%d%H%M%SZ').timetuple()))
+        out['notAfter'] = int(datetime.strptime(cert.get_notAfter().decode('UTF-8'),
+                                                            '%Y%m%d%H%M%SZ').timestamp())
+        out['notBefore'] = int(datetime.strptime(cert.get_notBefore().decode('UTF-8'),
+                                                             '%Y%m%d%H%M%SZ').timestamp())
         out['issuer'] = "".join(f"/{name.decode():s}={value.decode():s}"
                                 for name, value in cert.get_issuer().get_components())
         out['fullDN'] = f"{out['issuer']}{out['subject']}"

--- a/src/python/SiteRMLibs/ConfigFetcher.py
+++ b/src/python/SiteRMLibs/ConfigFetcher.py
@@ -47,7 +47,7 @@ class ConfigFetcher():
                 time.sleep(5)
             return retries
         output = {}
-        datetimeNow = datetime.datetime.now() + datetime.timedelta(minutes=10)
+        datetimeNow = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=10)
         filename = f"/tmp/{datetimeNow.strftime('%Y-%m-%d-%H')}-{name}.yaml"
         if os.path.isfile(filename):
             self.logger.info(f'Config files are not yet needed for update. For {name} from {url}')
@@ -102,7 +102,7 @@ class ConfigFetcher():
 
     def cleaner(self):
         """Clean files from /tmp/ directory"""
-        datetimeNow = datetime.datetime.now() + datetime.timedelta(minutes=10)
+        datetimeNow = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=10)
         for name in ["mapping", "Agent-main", "FE-main", "FE-auth"]:
             filename = f"/tmp/{datetimeNow.strftime('%Y-%m-%d-%H')}-{name}.yaml"
             if os.path.isfile(filename):

--- a/src/python/SiteRMLibs/DBBackend.py
+++ b/src/python/SiteRMLibs/DBBackend.py
@@ -19,17 +19,14 @@ Email                   : justas.balcas (at) cern.ch
 Date                    : 2019/05/01
 """
 import os
-import time
-import datetime
+from datetime import datetime, timezone
 import mariadb
 from SiteRMLibs import dbcalls
 
 
 def getUTCnow():
     """Get UTC Time."""
-    now = datetime.datetime.utcnow()
-    timestamp = int(time.mktime(now.timetuple()))
-    return timestamp
+    return int(datetime.now(timezone.utc).timestamp())
 
 
 def loadEnv(envFile='/etc/siterm-mariadb'):

--- a/src/python/SiteRMLibs/MainUtilities.py
+++ b/src/python/SiteRMLibs/MainUtilities.py
@@ -71,9 +71,7 @@ def isValFloat(inVal):
 
 def getUTCnow():
     """Get UTC Time."""
-    now = datetime.datetime.utcnow()
-    timestamp = int(time.mktime(now.timetuple()))
-    return timestamp
+    return int(datetime.datetime.now(datetime.timezone.utc).timestamp())
 
 
 def getVal(conDict, **kwargs):
@@ -338,7 +336,7 @@ def postWebContentToURL(url, **kwargs):
 def reCacheConfig(prevHour=None, prevDay=None):
     """Return prevHour == currentHour, currentHour and used in Service Object
     re-initiation."""
-    datetimeNow = datetime.datetime.now()
+    datetimeNow = datetime.datetime.now(datetime.timezone.utc)
     currentHour = datetimeNow.strftime("%H")
     currentDay = datetimeNow.strftime("%d")
     return prevHour == currentHour, currentDay == prevDay, currentHour, currentDay
@@ -618,7 +616,7 @@ def httpdate(timestamp):
 def httptimestamp(inhttpdate):
     """Return timestamp from RFC1123 (HTTP/1.1)."""
     dat = datetime.datetime(*eut.parsedate(inhttpdate)[:5])
-    return int(time.mktime(dat.timetuple()))
+    return int(dat.timestamp())
 
 
 def getModTime(headers):


### PR DESCRIPTION
Note: If no time zone is specified in incoming request (delta, http) by a 'Z' or a time offset, the time zone in which the date is expressed is local. To make sure not to hit this issue, always use timezone aware times. See issues here: https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated https://dateutil.readthedocs.io/en/stable/changelog.html